### PR TITLE
GHA: use "Environment file" in place of deprecated set-env()

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ${{ env.dockertag }}
     - name: save image
-      run: docker save -o ./image ${dockertag}
+      run: docker save -o ./image ${{ env.dockertag }}
     - name: Upload image
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     - name: define Docker tag
       run: echo "dockertag=my-image-name:$(git describe --always)"
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag git-$env:dockertag
+      run: docker build . --file Dockerfile --tag git-${{ env:dockertag }}
     - name: save image
       run: docker save -o ./image ${dockertag}
     - name: Upload image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     - name: define Docker tag
       run: echo "dockertag=my-image-name:$(git describe --always)" >>$GITHUB_ENV
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag git-${{ env:dockertag }}
+      run: docker build . --file Dockerfile --tag git-${{ env.dockertag }}
     - name: save image
       run: docker save -o ./image ${dockertag}
     - name: Upload image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: define Docker tag
-      run: echo "dockertag=my-image-name:$(git describe --always)"
+      run: echo "dockertag=my-image-name:$(git describe --always)" >>$GITHUB_ENV
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag git-${{ env:dockertag }}
     - name: save image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: define Docker tag
-      run: echo "dockertag=my-image-name:$(git describe --always)" >>$GITHUB_ENV
+      run: echo "dockertag=my-image-name:git-$(git describe --always)" >>$GITHUB_ENV
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag git-${{ env.dockertag }}
+      run: docker build . --file Dockerfile --tag ${{ env.dockertag }}
     - name: save image
       run: docker save -o ./image ${dockertag}
     - name: Upload image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: define Docker tag
-      run: echo "::set-env name=dockertag::my-image-name:$(date +%s)"
+      run: echo "::set-env name=dockertag::my-image-name:$(git describe --always)"
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag ${dockertag}
+      run: docker build . --file Dockerfile --tag git-${dockertag}
     - name: save image
       run: docker save -o ./image ${dockertag}
     - name: Upload image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: define Docker tag
-      run: echo "::set-env name=dockertag::my-image-name:$(git describe --always)"
+      run: echo "dockertag=my-image-name:$(git describe --always)"
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag git-${dockertag}
+      run: docker build . --file Dockerfile --tag git-$env:dockertag
     - name: save image
       run: docker save -o ./image ${dockertag}
     - name: Upload image


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/